### PR TITLE
Podman support

### DIFF
--- a/devcontainer.el
+++ b/devcontainer.el
@@ -17,6 +17,7 @@
 (require 'project)
 (require 'ansi-color)
 (require 'comint)
+(require 'tramp-container)
 
 (defcustom devcontainer-execute-outside-container '("grep" "rg" "ag")
   "A list of programs that should not be executed inside the devcontainer."

--- a/devcontainer.el
+++ b/devcontainer.el
@@ -534,10 +534,10 @@ are not yet supported."
   "Retrieve the defined remote environment of current project's devcontainer as alist if it's up."
   (when-let* ((metadata (devcontainer--container-metadata)))
     (mapcar (lambda (elt)
-              (cons (car elt) (devcontainer--interpolat-variable (cdr elt))))
+              (cons (car elt) (devcontainer--interpolate-variable (cdr elt))))
             (alist-get 'remoteEnv metadata))))
 
-(defun devcontainer--interpolat-variable (string)
+(defun devcontainer--interpolate-variable (string)
   "Interpolate devcontainer variable into STRING."
   (replace-regexp-in-string
    "\\${\\([[:alpha:]]+\\)\\(:[[:alpha:]]+\\)?}"
@@ -563,7 +563,7 @@ https://containers.dev/implementors/json_reference/#variables-in-devcontainerjso
                         (insert-file-contents (concat (file-name-as-directory (devcontainer--root)) devcontainer-json-file))
                         (devcontainer--bust-json-comments-in-buffer)
                         (json-parse-string (buffer-string)))))
-    (devcontainer--interpolat-variable (file-name-as-directory (gethash "workspaceFolder" config "/")))))
+    (devcontainer--interpolate-variable (file-name-as-directory (gethash "workspaceFolder" config "/")))))
 
 (defun devcontainer--bust-json-comments-in-buffer ()
   (while (re-search-forward "^\\([^\"]*?\\)\\(\\(\"[^\"]*\"[^\"]*?\\)*\\)//.*" nil t)

--- a/devcontainer.el
+++ b/devcontainer.el
@@ -84,8 +84,8 @@ Otherwise, raise an `error'."
   (append
    (list
     (devcontainer--find-executable)
-    (format "--docker-path=%s" (devcontainer--docker-path))
-    (format "--workspace-folder=%s" (devcontainer--root))
+    "--docker-path" (devcontainer--docker-path)
+    "--workspace-folder" (devcontainer--root)
     verb)
    ;; TODO dotfiles argument
    args))
@@ -154,9 +154,9 @@ Otherwise, raise an `error'."
        (let ((output (devcontainer--call-engine-string-sync
                       "container"
                       "ls"
-                      "--format={{.ID}}"
                       (format "--filter=label=devcontainer.local_folder=%s"
-                              (directory-file-name (devcontainer--root))))))
+                              (directory-file-name (devcontainer--root)))
+                      "--format={{.ID}}")))
          (devcontainer--set-current-project-state 'devcontainer-is-down)
          (when output
            (devcontainer--set-current-project-state 'devcontainer-is-up))
@@ -247,7 +247,9 @@ of the devcontainer stack simply remain alive."
   (interactive)
   (when-let ((container-id (or (devcontainer-container-id)
                                (user-error "No container to be removed"))))
-    (devcontainer-kill-container)
+    (devcontainer--call-engine-string-sync "container"
+                                           "kill"
+                                           container-id)
     (devcontainer--call-engine-string-sync "container"
                                            "rm"
                                            container-id)
@@ -511,8 +513,8 @@ are not yet supported."
              (car (process-lines (devcontainer--docker-path)
                                  "container"
                                  "inspect"
-                                 "--format={{json .Config.Env}}"
-                                 container-id))
+                                 container-id
+                                 "--format={{json .Config.Env}}"))
              :object-type 'alist))))
 
 (defun devcontainer--container-metadata ()

--- a/devcontainer.el
+++ b/devcontainer.el
@@ -23,6 +23,15 @@
   :group 'devcontainer
   :type '(repeat string))
 
+(defcustom devcontainer-engine 'docker
+  "The container engine to use, one of `docker' or `podman'.
+
+To specify the path of the podman/docker executable, customise
+`tramp-podman-program' or `tramp-docker-program'."
+  :group 'devcontainer
+  :type '(choice (const podman)
+                 (const docker)))
+
 (defvar devcontainer--project-info nil
   "The data structure for state of the devcontainer's of all active projects.
 

--- a/test/docker-fake.sh
+++ b/test/docker-fake.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+case $1 in
+    "null-result")
+	echo ""
+	;;
+    "error")
+	exit 1
+	;;
+    "one-line")
+	echo "$2"
+	;;
+esac


### PR DESCRIPTION
Lifted in large part from my package with a few of the things I learnt in between.

Managing devcontainer lifecycles using `devcontainer-up`, `devcontainer-remove-container` etc works on my system. Please verify if it works with dockerd.

None of the command execution stuff has been touched because it scares me and I think it either needs to be refactored to use `podman/docker exec` first #9 or some other solution using Tramp (loading each buffer as remote files, translating container `PATH` to remote-prefixed `exec-path` #11).

Closes #10.